### PR TITLE
chore: enhance release asset management in CI configuration

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -9,7 +9,7 @@ name: Gradle Package
 
 on:
   release:
-    types: [published]
+    types: [created, published]
 
 jobs:
   build:
@@ -38,8 +38,9 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build -Pversion=${{ github.event.release.tag_name }}
 
-#    - name: Set version from commit SHA
-#      run: echo "VERSION=dev-${GITHUB_SHA::6}" >> $GITHUB_ENV
+    - name: Create Distribution
+      run: |
+        ./gradlew installDist distZip distTar -Pversion=${{ github.event.release.tag_name }}
 
     # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
     # the publishing section of your build.gradle
@@ -48,3 +49,15 @@ jobs:
       env:
         GPR_USERNAME: ${{ github.actor }}
         GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Upload Release Assets
+      if: steps.semantic.outputs.new_release_published == 'true'
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: v${{ steps.semantic.outputs.new_release_version }}
+        files: |
+          build/libs/*.jar
+          build/distributions/*.zip
+          build/distributions/*.tar.gz
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -9,6 +9,22 @@
             }
         ],
         "@semantic-release/release-notes-generator",
-        "@semantic-release/github"
+        "@semantic-release/github",
+              {
+                "assets": [
+                  {
+                    "path": "build/libs/*.jar",
+                    "label": "JAR files"
+                  },
+                  {
+                    "path": "build/distributions/*.zip",
+                    "label": "Distribution ZIP"
+                  },
+                  {
+                    "path": "build/distributions/*.tar.gz",
+                    "label": "Distribution TAR.GZ"
+                  }
+                ]
+              }
     ]
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,21 @@ tasks.testFixturesJar {
 	enabled = false
 }
 
+distributions {
+	main {
+		distributionBaseName.set(project.name)
+	}
+}
+
+tasks.distZip {
+	archiveFileName.set("${project.name}-${project.version}.zip")
+}
+
+tasks.distTar {
+	archiveFileName.set("${project.name}-${project.version}.tar.gz")
+	compression = Compression.GZIP
+}
+
 publishing {
 	repositories {
 		maven {


### PR DESCRIPTION
Add support for uploading JAR and distribution files to GitHub releases. Update the CI workflow to create distribution archives and include them as assets.