### PR TITLE
fix: update semantic release configuration for versioning

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,28 +3,42 @@
     "plugins": [
         "@semantic-release/commit-analyzer",
         [
-            "@semantic-release/exec",
-            {
-                "verifyReleaseCmd": "echo \"NEXT_RELEASE_VERSION=${nextRelease.version}\" >> $GITHUB_OUTPUT"
-            }
+             "preset": "conventionalcommits",
+              "releaseRules": [
+                {"type": "feat", "release": "minor"},
+                {"type": "fix", "release": "patch"},
+                {"type": "docs", "release": "patch", "scope": "README"},
+                {"type": "perf", "release": "patch"},
+                {"type": "refactor", "release": "patch"},
+                {"type": "style", "release": false},
+                {"type": "test", "release": false},
+                {"type": "build", "release": false},
+                {"type": "ci", "release": false},
+                {"type": "chore", "release": false},
+                {"breaking": true, "release": "major"},
+                {"revert": true, "release": "patch"}
+              ],
+              "parserOpts": {
+                "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+              }
         ],
         "@semantic-release/release-notes-generator",
         "@semantic-release/github",
-              {
-                "assets": [
-                  {
-                    "path": "build/libs/*.jar",
-                    "label": "JAR files"
-                  },
-                  {
-                    "path": "build/distributions/*.zip",
-                    "label": "Distribution ZIP"
-                  },
-                  {
-                    "path": "build/distributions/*.tar.gz",
-                    "label": "Distribution TAR.GZ"
-                  }
-                ]
-              }
+        {
+          "assets": [
+            {
+              "path": "build/libs/*.jar",
+              "label": "JAR files"
+            },
+            {
+              "path": "build/distributions/*.zip",
+              "label": "Distribution ZIP"
+            },
+            {
+              "path": "build/distributions/*.tar.gz",
+              "label": "Distribution TAR.GZ"
+            }
+          ]
+        }
     ]
 }


### PR DESCRIPTION
Refine release rules to align with conventional commits. Adjust parser options for better handling of breaking changes.